### PR TITLE
Fix template setting syntax

### DIFF
--- a/workoutTracker/settings.py
+++ b/workoutTracker/settings.py
@@ -54,8 +54,7 @@ ROOT_URLCONF = 'workoutTracker.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [BASE_DIR / 'templates']
-        ,
+        'DIRS': [BASE_DIR / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [


### PR DESCRIPTION
## Summary
- remove stray comma in the templates setting

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68416dad7bc88322b09f50fb877e2a7b